### PR TITLE
Add the ability to define a seperate slug for a repository

### DIFF
--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -218,7 +218,9 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("has_wiki", repo.HasWiki)
 		d.Set("has_issues", repo.HasIssues)
 		d.Set("name", repo.Name)
-		d.Set("slug", repo.Slug)
+		if repo.Slug != "" && repo.Name != repo.Slug {
+			d.Set("slug", repo.Slug)
+		}
 		d.Set("language", repo.Language)
 		d.Set("fork_policy", repo.ForkPolicy)
 		d.Set("website", repo.Website)

--- a/bitbucket/resource_repository_test.go
+++ b/bitbucket/resource_repository_test.go
@@ -35,6 +35,33 @@ func TestAccBitbucketRepository_basic(t *testing.T) {
 	})
 }
 
+func TestAccBitbucketRepository_camelcase(t *testing.T) {
+	var repo Repository
+
+	testUser := os.Getenv("BITBUCKET_USERNAME")
+	testAccBitbucketRepositoryConfig := fmt.Sprintf(`
+		resource "bitbucket_repository" "test_repo" {
+			owner = "%s"
+			name = "TestRepoForRepositoryTest"
+			slug = "test-repo-for-repository-test"
+		}
+	`, testUser)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBitbucketRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBitbucketRepositoryConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBitbucketRepositoryExists("bitbucket_repository.test_repo", &repo),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBitbucketRepositoryDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*BitbucketClient)
 	rs, ok := s.RootModule().Resources["bitbucket_repository.test_repo"]

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -23,13 +23,26 @@ resource "bitbucket_repository" "infrastructure" {
 }
 ```
 
+If you want to create a repository with a CamelCase name, you should provide
+a seperate slug
+
+```hcl
+# Manage your repository
+resource "bitbucket_repository" "infrastructure" {
+  owner = "myteam"
+  name  = "TerraformCode"
+  slug  = "terraform-code"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `owner` - (Required) The owner of this repository. Can be you or any team you
   have write access to.
-* `name` - (Optional) The name of the repository.
+* `name` - (Required) The name of the repository.
+* `slug` - (Optional) The slug of the repository.
 * `scm` - (Optional) What SCM you want to use. Valid options are hg or git.
   Defaults to git.
 * `is_private` - (Optional) If this should be private or not. Defaults to `true`.


### PR DESCRIPTION
Ability to define a slug instead of using the name. If no slug is defined the name will be used (current implementations should not be affected)

Fixes #4 