### PR TITLE
Fix repository resource importability

### DIFF
--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
 )
 
 type CloneUrl struct {
@@ -186,6 +187,16 @@ func resourceRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	return resourceRepositoryRead(d, m)
 }
 func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
+	id := d.Id()
+	if id != "" {
+		idparts := strings.Split(id, "/")
+		if len(idparts) == 2 {
+			d.Set("owner", idparts[0])
+			d.Set("slug", idparts[1])
+		} else {
+			return fmt.Errorf("Incorrect ID format, should match `owner/slug`")
+		}
+	}
 
 	var repoSlug string
 	repoSlug = d.Get("slug").(string)

--- a/website/docs/r/repository.html.markdown
+++ b/website/docs/r/repository.html.markdown
@@ -63,8 +63,8 @@ The following arguments are computed. You can access both `clone_ssh` and
 
 ## Import
 
-Repositories can be imported using the `name`, e.g.
+Repositories can be imported using their `owner/name` ID, e.g.
 
 ```
-$ terraform import bitbucket_repository.my-repo my-repo
+$ terraform import bitbucket_repository.my-repo my-account/my-repo
 ```


### PR DESCRIPTION
ImportStatePassthrough requires ID only refresh capability.

Without this fix, the API request is incorrect (`https://api.bitbucket.org/2.0/repositories//`), the ID of the imported resource stored in the state is incorrect and fields are not correctly populated with actual state:

```
bitbucket_repository.test: Import complete!                                                                                                                                                                    
  Imported bitbucket_repository (ID: test)                                                                                                                                                                     
2017/08/25 16:52:25 [TRACE] dag/walk: added new vertex: "import bitbucket_repository.test result: test"                                                                                                        
2017/08/25 16:52:25 [TRACE] dag/walk: walking "import bitbucket_repository.test result: test"                                                                                                                  
2017/08/25 16:52:25 [TRACE] vertex 'root.import bitbucket_repository.test result: test': walking                                                                                                               
2017/08/25 16:52:25 [TRACE] vertex 'root.import bitbucket_repository.test result: test': evaluating                                                                                                            
2017/08/25 16:52:25 [TRACE] [walkImport] Entering eval tree: import bitbucket_repository.test result: test                                                                                                     
2017/08/25 16:52:25 [TRACE] root: eval: *terraform.EvalSequence                                                                                                                                                
2017/08/25 16:52:25 [TRACE] root: eval: *terraform.EvalGetProvider                                                                                                                                             
2017/08/25 16:52:25 [TRACE] root: eval: *terraform.EvalRefresh                                                                                                                                                 
bitbucket_repository.test: Refreshing state... (ID: test)                                                                                                                                                      
2017-08-25T16:52:25.628+0200 [DEBUG] plugin.terraform-provider-bitbucket: 2017/08/25 16:52:25 [DEBUG] Sending request to GET https://api.bitbucket.org/2.0/repositories//                                      
2017-08-25T16:52:26.220+0200 [DEBUG] plugin.terraform-provider-bitbucket: 2017/08/25 16:52:26 [DEBUG] Resp: &{404 Not Found 404 HTTP/2.0 2 0 map[Date:[Fri, 25 Aug 2017 14:52:26 GMT] X-Render-Time:[0.0351650$
```

With the fix, the resource is correctly read:

```
bitbucket_repository.test: Import complete!                                                                  
  Imported bitbucket_repository (ID: patrick_decat/test)                                                                                                                                                       2017/08/25 17:26:11 [TRACE] dag/walk: added new vertex: "import bitbucket_repository.test result: patrick_decat/test"
2017/08/25 17:26:11 [TRACE] dag/walk: walking "import bitbucket_repository.test result: patrick_decat/test"                       
2017/08/25 17:26:11 [TRACE] vertex 'root.import bitbucket_repository.test result: patrick_decat/test': walking
2017/08/25 17:26:11 [TRACE] vertex 'root.import bitbucket_repository.test result: patrick_decat/test': evaluating
2017/08/25 17:26:11 [TRACE] [walkImport] Entering eval tree: import bitbucket_repository.test result: patrick_decat/test
2017/08/25 17:26:11 [TRACE] root: eval: *terraform.EvalSequence      
2017/08/25 17:26:11 [TRACE] root: eval: *terraform.EvalGetProvider                                             
2017/08/25 17:26:11 [TRACE] root: eval: *terraform.EvalRefresh            
bitbucket_repository.test: Refreshing state... (ID: patrick_decat/test)                          
2017-08-25T17:26:11.869+0200 [DEBUG] plugin.terraform-provider-bitbucket: 2017/08/25 17:26:11 [DEBUG] Sending request to GET https://api.bitbucket.org/2.0/repositories/patrick_decat/test
2017-08-25T17:26:12.535+0200 [DEBUG] plugin.terraform-provider-bitbucket: 2017/08/25 17:26:12 [DEBUG] Resp: &{200 OK 200 HTTP/2.0 2 0 map[Vary:[Authorization Accept-Encoding] Strict-Transport-Security:[max-a
```

PS: the import command does not fail if the API resource does not exist because the read function does not fail in case of 404, it only tests for 200 to proceed. That probably also needs to be fixed.