### PR TITLE
Handle missing hooks

### DIFF
--- a/bitbucket/resource_hook.go
+++ b/bitbucket/resource_hook.go
@@ -193,6 +193,13 @@ func resourceHookExists(d *schema.ResourceData, m interface{}) (bool, error) {
 		))
 
 		if err != nil {
+			log.Printf("[DEBUG] Req: %+v, Err: %+v", hook_req, err)
+			// If the hook was not found, we get the message "is not a valid hook".
+			// Return nil so we can show that the hook is gone.
+			if hook_req.StatusCode == 404 {
+				return false, nil
+			}
+
 			panic(err)
 		}
 


### PR DESCRIPTION
When deleting a hook outside of Terraform then running Terraform again, it blows up with messages like the following:

```
API Error: 404 2.0/repositories/owner/repoName/hooks/{uuid} repoName is not a valid hook
```

which makes the run fail.

Unfortunately I wasn't able to figure out a more rigorous method of checking the error returned, Go is not a strong language for me. Feel free to edit this.