### PR TITLE
Removed Username from BitBucket representation

### DIFF
--- a/bitbucket/resource_default_reviewers.go
+++ b/bitbucket/resource_default_reviewers.go
@@ -10,7 +10,6 @@ import (
 type Reviewer struct {
 	DisplayName string `json:"display_name,omitempty"`
 	UUID        string `json:"uuid,omitempty"`
-	Username    string `json:"username,omitempty"`
 	Type        string `json:"type,omitempty"`
 }
 
@@ -98,7 +97,7 @@ func resourceDefaultReviewersRead(d *schema.ResourceData, m interface{}) error {
 		}
 
 		for _, reviewer := range reviewers.Values {
-			terraformReviewers = append(terraformReviewers, reviewer.Username)
+			terraformReviewers = append(terraformReviewers, reviewer.UUID)
 		}
 
 		if reviewers.Next != "" {


### PR DESCRIPTION
Uses UUID in requests to default reviewers instead of username

Bitbucket made a breaking change, removing the support
for referencing (and returning) usernames directly.

Naiive fix for issue #37