### PR TITLE
Fix readme error 'make bin' should be 'make build' target #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-bitbucket
 ...


### PR DESCRIPTION
This PR is to fix a minor issue with the readme on make targets