### PR TITLE
Removed omitempty, as it caused HTTP 400s when bools were false.

### DIFF
--- a/bitbucket/resource_hook.go
+++ b/bitbucket/resource_hook.go
@@ -16,8 +16,8 @@ type Hook struct {
 	UUID                 string   `json:"uuid,omitempty"`
 	URL                  string   `json:"url,omitempty"`
 	Description          string   `json:"description,omitempty"`
-	Active               bool     `json:"active,omitempty"`
-	SkipCertVerification bool     `json:"skip_cert_verification,omitempty"`
+	Active               bool     `json:"active"`
+	SkipCertVerification bool     `json:"skip_cert_verification"`
 	Events               []string `json:"events,omitempty"`
 }
 


### PR DESCRIPTION
Sample showing why `omitempty` was removed https://goplay.space/#3yw8DItT_sW

I ran into HTTP 400s when setting `SkipCertVerification` to false, because this property was not being sent in the payload to bitbucket. This PR fixes this error by always sending the parameters, even when `false`. 