### PR TITLE
Branch restriction `require_default_reviewer_approvals_to_merge` is n…

### DIFF
--- a/bitbucket/resource_branch_restriction.go
+++ b/bitbucket/resource_branch_restriction.go
@@ -65,6 +65,7 @@ func resourceBranchRestriction() *schema.Resource {
 					"restrict_merges",
 					"reset_pullrequest_approvals_on_change",
 					"delete",
+					"require_default_reviewer_approvals_to_merge",
 				},
 					false),
 			},


### PR DESCRIPTION
A new merge check has been included in Bitbucket lately.