### PR TITLE
Add Data Source: terraform_repository

### DIFF
--- a/bitbucket/data_repository.go
+++ b/bitbucket/data_repository.go
@@ -1,0 +1,108 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataRepository() *schema.Resource {
+	return &schema.Resource{
+		Read: dataReadRepository,
+
+		Schema: RepositorySchema,
+	}
+}
+
+func dataReadRepository(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	owner := d.Get("owner")
+	if owner == "" {
+		return fmt.Errorf("owner must not be blank")
+	}
+
+	var repoSlug string
+	repoSlug = d.Get("slug").(string)
+	if repoSlug == "" {
+		repoSlug = d.Get("name").(string)
+	}
+	if repoSlug == "" {
+		return fmt.Errorf("repo slug or name must not be blank")
+	}
+
+	repoReq, err := client.Get(fmt.Sprintf("2.0/repositories/%s/%s",
+		owner,
+		repoSlug,
+	))
+	if err != nil {
+		return err
+	}
+
+	if repoReq.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("repo not found")
+	}
+
+	if repoReq.StatusCode >= http.StatusInternalServerError {
+		return fmt.Errorf("internal server error fetching repository")
+	}
+
+	var repo Repository
+
+	body, readerr := ioutil.ReadAll(repoReq.Body)
+	if readerr != nil {
+		return readerr
+	}
+
+	decodeerr := json.Unmarshal(body, &repo)
+	if decodeerr != nil {
+		return decodeerr
+	}
+
+	d.SetId(string(fmt.Sprintf("%s/%s", owner, repoSlug)))
+	d.Set("scm", repo.SCM)
+	d.Set("is_private", repo.IsPrivate)
+	d.Set("has_wiki", repo.HasWiki)
+	d.Set("has_issues", repo.HasIssues)
+	d.Set("name", repo.Name)
+	if repo.Slug != "" && repo.Name != repo.Slug {
+		d.Set("slug", repo.Slug)
+	}
+	d.Set("language", repo.Language)
+	d.Set("fork_policy", repo.ForkPolicy)
+	d.Set("website", repo.Website)
+	d.Set("description", repo.Description)
+	d.Set("project_key", repo.Project.Key)
+
+	for _, cloneURL := range repo.Links.Clone {
+		if cloneURL.Name == "https" {
+			d.Set("clone_https", cloneURL.Href)
+		} else {
+			d.Set("clone_ssh", cloneURL.Href)
+		}
+	}
+	pipelinesConfigReq, err := client.Get(fmt.Sprintf("2.0/repositories/%s/%s/pipelines_config",
+		owner,
+		repoSlug))
+
+	if err == nil && pipelinesConfigReq.StatusCode == 200 {
+		var pipelinesConfig PipelinesEnabled
+
+		body, readerr := ioutil.ReadAll(pipelinesConfigReq.Body)
+		if readerr != nil {
+			return readerr
+		}
+
+		decodeerr := json.Unmarshal(body, &pipelinesConfig)
+		if decodeerr != nil {
+			return decodeerr
+		}
+
+		d.Set("pipelines_enabled", pipelinesConfig.Enabled)
+	}
+
+	return nil
+}

--- a/bitbucket/provider.go
+++ b/bitbucket/provider.go
@@ -33,7 +33,8 @@ func Provider() terraform.ResourceProvider {
 			"bitbucket_branch_restriction":  resourceBranchRestriction(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"bitbucket_user": dataUser(),
+			"bitbucket_user":       dataUser(),
+			"bitbucket_repository": dataRepository(),
 		},
 	}
 }

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -43,6 +43,76 @@ type Repository struct {
 	} `json:"links,omitempty"`
 }
 
+var RepositorySchema = map[string]*schema.Schema{
+	"scm": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "git",
+	},
+	"has_wiki": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"has_issues": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"website": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"clone_ssh": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"clone_https": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"project_key": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"is_private": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"pipelines_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"fork_policy": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "allow_forks",
+	},
+	"language": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"description": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"owner": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"slug": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+	},
+}
+
 func resourceRepository() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceRepositoryCreate,
@@ -53,75 +123,7 @@ func resourceRepository() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"scm": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "git",
-			},
-			"has_wiki": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"has_issues": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"website": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"clone_ssh": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"clone_https": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"project_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"is_private": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"pipelines_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"fork_policy": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "allow_forks",
-			},
-			"language": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"owner": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"slug": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-		},
+		Schema: RepositorySchema,
 	}
 }
 
@@ -234,6 +236,7 @@ func resourceRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 
 	return resourceRepositoryRead(d, m)
 }
+
 func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
 	if id != "" {


### PR DESCRIPTION
This is a nice to have so we don't have to initially create our repo in bitbucket. Usually devs create a repo then our ops team helps with setting up CI/CD to an existing repo. 

This is my first Go code/mod - please feel free to make suggestions.

Also it could probably use some more test coverage. The other data source didn't have any, but we should probably get some going. That might be my next task.